### PR TITLE
Remove `RH` from mqname

### DIFF
--- a/nilan_code.ino
+++ b/nilan_code.ino
@@ -402,7 +402,7 @@ void loop()
               case reqtemp:
                 if (strncmp("RH", name, 2) == 0)
                 {
-                  mqname = "moist/nilan/RH"; // Subscribe to moisture-level
+                  mqname = "moist/nilan/"; // Subscribe to moisture-level
                 }
                 dtostrf((rsbuffer[i] / 100.0), 5, 2, numstr);
                 break;


### PR DESCRIPTION
It will be appended later - right now you end up with `moist/nilan/RHRH`