### PR TITLE
Moving RH and temp sensors into ventilation topic.

### DIFF
--- a/nilan_code/nilan_code.ino
+++ b/nilan_code/nilan_code.ino
@@ -417,9 +417,10 @@ void loop()
                 itoa((rsbuffer[i]), numstr, 10);
                 break;          
               case reqtemp:
-                if (strncmp("RH", name, 2) == 0)
-                {
-                  mqname = "moist/nilan/"; // Subscribe to moisture-level
+                if (strncmp("RH", name, 2) == 0) {
+                  mqname = "ventilation/moist/"; // Subscribe to moisture-level
+                } else {
+                  mqname = "ventilation/temp/"; // Subscribe to "temp" register
                 }
                 dtostrf((rsbuffer[i] / 100.0), 5, 2, numstr);
                 break;


### PR DESCRIPTION
I think it's an error from way past that temperature sensors ended up in `temp`. Now that I read the code and thought about it, it seemed like `temp` didn't mean `temperature` but `temporary` and were forgotten because of the mistake. This PR moves it into `ventilation/temp` where I feel it really should be (gathering everything under `ventilation`). This also moves RH from `moist/nilan` to `ventilation/moist`.